### PR TITLE
연산자 우선순위 처리

### DIFF
--- a/piece/calculation.ts
+++ b/piece/calculation.ts
@@ -1,5 +1,12 @@
-import { EvaluatablePiece, OperatorPiece } from './index.ts'
+import { EvaluatablePiece, OperatorPiece, ValueTypes } from './index.ts'
 import { CallFrame, Scope } from '../scope.ts'
+
+const precedence: Array<string[]> = [
+    [], // 0 (safety area)
+    ['=', '<', '>', '<=', '>='], // 1
+    ['-', '+'], // 2
+    ['*', '/'], // 3
+]
 
 export class BinaryCalculationPiece extends EvaluatablePiece {
     left: EvaluatablePiece
@@ -18,14 +25,64 @@ export class BinaryCalculationPiece extends EvaluatablePiece {
         this.operator = props.operator
     }
 
+    getPieceArray(
+        scope: Scope,
+        _callFrame: CallFrame,
+    ): Array<EvaluatablePiece | OperatorPiece> {
+        const { left, right, operator } = this
+        let leftValue: Array<EvaluatablePiece | OperatorPiece>
+        let rightValue: Array<EvaluatablePiece | OperatorPiece>
+
+        if (left instanceof BinaryCalculationPiece) {
+            leftValue = left.getPieceArray(scope, _callFrame)
+        } else {
+            leftValue = [left]
+        }
+
+        if (right instanceof BinaryCalculationPiece) {
+            rightValue = right.getPieceArray(scope, _callFrame)
+        } else {
+            rightValue = [right]
+        }
+
+        return [...leftValue, operator, ...rightValue]
+    }
+
     execute(scope: Scope, _callFrame: CallFrame) {
         const callFrame = new CallFrame(this, _callFrame)
-        const { left, right, operator } = this
 
-        const leftValue = left.execute(scope, callFrame)
-        const rightValue = right.execute(scope, callFrame)
+        const underPieces = this.getPieceArray(scope, callFrame)
 
-        return operator.call(leftValue, rightValue)
+        let targetPrecedence = precedence.length - 1
+
+        while (underPieces.length > 1) {
+            for (let i = 0; i < underPieces.length; i++) {
+                const piece = underPieces[i]
+                if (!(piece instanceof OperatorPiece)) continue
+                let currentPrecedence = precedence.findIndex((p) => {
+                    return p.includes((piece as OperatorPiece).value)
+                })
+                if (currentPrecedence === -1) currentPrecedence = 0
+
+                if (targetPrecedence === currentPrecedence) {
+                    const left = underPieces[i - 1] as EvaluatablePiece
+                    const right = underPieces[i + 1] as EvaluatablePiece
+                    const operator = piece as OperatorPiece
+
+                    const leftValue = left.execute(scope, callFrame)
+                    const rightValue = right.execute(scope, callFrame)
+
+                    const result = operator.call(leftValue, rightValue)
+
+                    underPieces.splice(i - 1, 3, result)
+
+                    i--
+                }
+            }
+            targetPrecedence--
+        }
+
+        return underPieces[0] as ValueTypes
     }
 }
 

--- a/piece/operator.ts
+++ b/piece/operator.ts
@@ -8,6 +8,10 @@ import {
 } from './primitive.ts'
 
 export class PlusOperatorPiece extends OperatorPiece {
+    constructor() {
+        super('+')
+    }
+
     call(...operands: ValueTypes[]) {
         if (operands.length !== 2) {
             throw new YaksokError('INVALID_NUMBER_OF_OPERANDS')
@@ -36,6 +40,10 @@ export class PlusOperatorPiece extends OperatorPiece {
 }
 
 export class MinusOperatorPiece extends OperatorPiece {
+    constructor() {
+        super('-')
+    }
+
     call(...operands: ValueTypes[]) {
         if (operands.length !== 2) {
             throw new YaksokError('INVALID_NUMBER_OF_OPERANDS')
@@ -51,6 +59,10 @@ export class MinusOperatorPiece extends OperatorPiece {
 }
 
 export class MultiplyOperatorPiece extends OperatorPiece {
+    constructor() {
+        super('*')
+    }
+
     call(...operands: ValueTypes[]) {
         if (operands.length !== 2) {
             throw new YaksokError('INVALID_NUMBER_OF_OPERANDS')
@@ -70,6 +82,10 @@ export class MultiplyOperatorPiece extends OperatorPiece {
 }
 
 export class DivideOperatorPiece extends OperatorPiece {
+    constructor() {
+        super('/')
+    }
+
     call(...operands: ValueTypes[]) {
         if (operands.length !== 2) {
             throw new YaksokError('INVALID_NUMBER_OF_OPERANDS')
@@ -86,6 +102,10 @@ export class DivideOperatorPiece extends OperatorPiece {
 }
 
 export class EqualOperatorPiece extends OperatorPiece {
+    constructor() {
+        super('=')
+    }
+
     call(...operands: ValueTypes[]) {
         if (operands.length !== 2) {
             throw new YaksokError('INVALID_NUMBER_OF_OPERANDS')
@@ -126,6 +146,10 @@ export class AndOperatorPiece extends OperatorPiece {
 }
 
 export class GreaterThanOperatorPiece extends OperatorPiece {
+    constructor() {
+        super('>')
+    }
+
     call(...operands: ValueTypes[]) {
         if (operands.length !== 2) {
             throw new YaksokError('INVALID_NUMBER_OF_OPERANDS')
@@ -142,6 +166,10 @@ export class GreaterThanOperatorPiece extends OperatorPiece {
 }
 
 export class LessThanOperatorPiece extends OperatorPiece {
+    constructor() {
+        super('<')
+    }
+
     call(...operands: ValueTypes[]) {
         if (operands.length !== 2) {
             throw new YaksokError('INVALID_NUMBER_OF_OPERANDS')
@@ -158,6 +186,10 @@ export class LessThanOperatorPiece extends OperatorPiece {
 }
 
 export class GreaterThanOrEqualOperatorPiece extends OperatorPiece {
+    constructor() {
+        super('>=')
+    }
+
     call(...operands: ValueTypes[]) {
         if (operands.length !== 2) {
             throw new YaksokError('INVALID_NUMBER_OF_OPERANDS')
@@ -174,6 +206,10 @@ export class GreaterThanOrEqualOperatorPiece extends OperatorPiece {
 }
 
 export class LessThanOrEqualOperatorPiece extends OperatorPiece {
+    constructor() {
+        super('<=')
+    }
+
     call(...operands: ValueTypes[]) {
         if (operands.length !== 2) {
             throw new YaksokError('INVALID_NUMBER_OF_OPERANDS')


### PR DESCRIPTION
먼저, 기본적인 연산자 우선순위는 [파이선 공식 문서](https://docs.python.org/3/reference/expressions.html#operator-precedence)를 참고하였습니다.

```
숫자: 2 + 5 * (4 + 4) / 2

숫자 보여주기
```
이 PR의 변경점을 통해 위 코드를 실행하였을 때 `22`라는 정상적인 출력을 함을 확인하였습니다.

먼저 연산 우선순위 처리를 위하여 각 OperatorPiece를 구분해낼 필요가 있었으나, 클래스의 instanceof로 구분하려 시도했으나 의도대로 작동하지 않아 OperatorPiece에 존재하나 빈 값으로 남아있는 value에 constructor - super를 이용하여 본인의 연산자를 저장할 수 있도록 하였습니다. (operator.ts 변경사항)

이 과정에서 `calculation.ts`에 미리 연산자 우선순위에 맞춰 배열을 작성하였습니다.
```ts
const precedence: Array<string[]> = [
    [], // 0 (safety area)
    ['=', '<', '>', '<=', '>='], // 1
    ['-', '+'], // 2
    ['*', '/'], // 3
]
```

이후 최상위 BinaryCalculationPiece에서 하위 BinaryCalculationPiece들을 탐색하며 계산의 묶음을 EvaluatablePiece와 OperatorPiece로 구성된 배열로 풀어냅니다. 이를 위하여 하위 Piece를 탐색하는 함수를 분리하였습니다. (getPieceArray 함수 - calculation.ts:28) 이 때, 괄호연산은 EvaluatablePiece에 포함되는 ValueGroupPiece로 처리되어 우선순위를 유지합니다. (괄호 주변의 연산을 처리하기 위해선 ValueGroupPiece를 연산해야 합니다) 해당 결과는 다음과 같습니다.
```ts
[
  NumberPiece { value: 2 },
  PlusOperatorPiece { value: "+" },
  NumberPiece { value: 5 },
  MultiplyOperatorPiece { value: "*" },
  ValueGroupPiece {
    value: BinaryCalculationPiece {
      left: NumberPiece { value: 4 },
      right: NumberPiece { value: 4 },
      operator: PlusOperatorPiece { value: "+" }
    }
  },
  DivideOperatorPiece { value: "/" },
  NumberPiece { value: 2 }
]
```
계산의 결과값이 나올때까지(= 배열의 요소가 한개밖에 남지 않을때까지) 배열의 각 요소를 반복하며 precedence 배열에 맞춰 OperatorPiece를 기준으로 연산해나가며(calculation.ts:56 ~ 83), 마지막 하나 남은 연산 결과를 ValueTypes의 형태로 반환하며 연산을 마무리하게 됩니다.

이때, precedence배열의 첫 항을 빈 값으로 남겨두어, 연산자 우선순위에 등록되지 않았을 경우 오류가 아닌 최하위 연산자로 취급하여 작동하도록 하였습니다.