### PR TITLE
feat: optimistic tokenizer

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -40,7 +40,7 @@
         }
     },
     "name": "@dalbit-yaksok/core",
-    "version": "0.2.0-alpha.8+20241208.nightly",
+    "version": "0.2.0-alpha.9+20241212.nightly",
     "exports": "./src/mod.ts",
     "nodeModulesDir": "auto",
     "workspace": [

--- a/quickjs/deno.json
+++ b/quickjs/deno.json
@@ -5,5 +5,5 @@
         "quickjs-emscripten": "npm:quickjs-emscripten@^0.31.0",
         "quickjs-emscripten-core": "npm:quickjs-emscripten-core@^0.31.0"
     },
-    "version": "0.2.0-alpha.8+20241208.nightly"
+    "version": "0.2.0-alpha.9+20241212.nightly"
 }

--- a/runtest.ts
+++ b/runtest.ts
@@ -1,6 +1,46 @@
-import { yaksok } from '@yaksok-ts/core'
+import { tokenize } from '@dalbit-yaksok/core'
 
-await yaksok(`
-약속, (음식 10)을 맛있게 만들기
-    음식 + "을/를 맛있게 만들었습니다." 보여주기
-`)
+const CODE = `약속, 회전설정 (회전)
+    결과: "rotate:" + 회전
+
+약속, 시간설정 (시간)
+    결과: "time:" + 시간
+
+약속, (A) 합 (B)
+    결과: A + "<join>" + B
+
+약속, (각도)도 회전하기
+    회전설정 각도 보여주기
+
+약속, (시간)초 동안 (각도)도 회전하기
+    (시간설정 시간) 합 (회전설정 각도) 보여주기
+
+각도: 45
+시간: 30
+
+(3)초 동안 (90)도 회전하기
+3 초 동안 90 도 회전하기
+(3)초 동안 90 도 회전하기
+3 초 동안 (90)도 회전하기
+
+시간 초 동안 각도 도 회전하기
+(시간)초 동안 (각도)도 회전하기
+(시간)초 동안 각도 도 회전하기
+시간 초 동안 (각도)도 회전하기
+
+(90)도 회전하기
+90 도 회전하기
+각도 도 회전하기
+(각도)도 회전하기`
+
+for (let i = 0; i < CODE.length; i++) {
+    const tokens = tokenize(CODE.slice(0, i))
+    const lastToken = tokens[tokens.length - 1]
+}
+
+const MASK_SIZE = 8
+
+for (let i = 0; i < CODE.length - MASK_SIZE; i++) {
+    const maskedCode = CODE.slice(0, i) + CODE.slice(i + MASK_SIZE)
+    const tokens = tokenize(maskedCode)
+}

--- a/runtest.ts
+++ b/runtest.ts
@@ -1,8 +1,8 @@
-import { tokenize } from '@dalbit-yaksok/core'
+import { yaksok } from '@dalbit-yaksok/core'
 
 const CODE = `약속, 회전설정 (회전)
     결과: "rotate:" + 회전
-
+내 이름: "정한";
 약속, 시간설정 (시간)
     결과: "time:" + 시간
 
@@ -33,14 +33,4 @@ const CODE = `약속, 회전설정 (회전)
 각도 도 회전하기
 (각도)도 회전하기`
 
-for (let i = 0; i < CODE.length; i++) {
-    const tokens = tokenize(CODE.slice(0, i))
-    const lastToken = tokens[tokens.length - 1]
-}
-
-const MASK_SIZE = 8
-
-for (let i = 0; i < CODE.length - MASK_SIZE; i++) {
-    const maskedCode = CODE.slice(0, i) + CODE.slice(i + MASK_SIZE)
-    const tokens = tokenize(maskedCode)
-}
+yaksok(CODE)

--- a/runtest.ts
+++ b/runtest.ts
@@ -1,4 +1,4 @@
-import { yaksok } from '@dalbit-yaksok/core'
+import { tokenize } from '@dalbit-yaksok/core'
 
 const CODE = `약속, 회전설정 (회전)
     결과: "rotate:" + 회전
@@ -33,4 +33,4 @@ const CODE = `약속, 회전설정 (회전)
 각도 도 회전하기
 (각도)도 회전하기`
 
-yaksok(CODE)
+tokenize(CODE)

--- a/src/prepare/lex/convert-tokens-to-nodes.ts
+++ b/src/prepare/lex/convert-tokens-to-nodes.ts
@@ -1,3 +1,4 @@
+import { UnexpectedCharError } from '../../error/prepare.ts'
 import { Expression, Identifier, Node, Operator } from '../../node/base.ts'
 import { FFIBody } from '../../node/ffi.ts'
 import { Mention } from '../../node/mention.ts'
@@ -38,5 +39,12 @@ function mapTokenToNode(token: Token) {
             return null
         case TOKEN_TYPE.MENTION:
             return new Mention(token.value.slice(1), token.position)
+        case TOKEN_TYPE.UNKNOWN:
+            throw new UnexpectedCharError({
+                resource: {
+                    parts: '코드',
+                    char: token.value,
+                },
+            })
     }
 }

--- a/src/prepare/lex/convert-tokens-to-nodes.ts
+++ b/src/prepare/lex/convert-tokens-to-nodes.ts
@@ -3,7 +3,7 @@ import { FFIBody } from '../../node/ffi.ts'
 import { Mention } from '../../node/mention.ts'
 import { Indent, EOL } from '../../node/misc.ts'
 import { NumberLiteral, StringLiteral } from '../../node/primitive-literal.ts'
-import { Token, TOKEN_TYPE } from './token.ts'
+import { Token, TOKEN_TYPE } from '../tokenize/token.ts'
 
 export function convertTokensToNodes(tokens: Token[]): Node[] {
     return tokens.map(mapTokenToNode).filter(Boolean) as Node[]

--- a/src/prepare/lex/indent-validity.ts
+++ b/src/prepare/lex/indent-validity.ts
@@ -2,7 +2,7 @@ import {
     IndentIsNotMultipleOf4Error,
     IndentLevelMismatchError,
 } from '../../error/prepare.ts'
-import { Token, TOKEN_TYPE } from './token.ts'
+import { Token, TOKEN_TYPE } from '../tokenize/token.ts'
 
 export function assertIndentValidity(_tokens: Token[]) {
     const tokens = trimTokens(_tokens)

--- a/src/prepare/lex/merge-argument-branching-tokens.ts
+++ b/src/prepare/lex/merge-argument-branching-tokens.ts
@@ -1,5 +1,5 @@
 import { UnexpectedEndOfCodeError } from '../../error/prepare.ts'
-import { Token, TOKEN_TYPE } from './token.ts'
+import { Token, TOKEN_TYPE } from '../tokenize/token.ts'
 
 export function mergeArgumentBranchingTokens(
     _tokens: Token[],

--- a/src/prepare/parse/index.ts
+++ b/src/prepare/parse/index.ts
@@ -1,4 +1,4 @@
-import { convertTokensToNodes } from '../tokenize/convert-tokens-to-nodes.ts'
+import { convertTokensToNodes } from '../lex/convert-tokens-to-nodes.ts'
 import { createDynamicRule } from './dynamicRule/index.ts'
 import { SetVariable } from '../../node/variable.ts'
 import { callParseRecursively } from './srParse.ts'

--- a/src/prepare/tokenize/indent-validity.ts
+++ b/src/prepare/tokenize/indent-validity.ts
@@ -5,10 +5,10 @@ import {
 import { Token, TOKEN_TYPE } from './token.ts'
 
 export function assertIndentValidity(_tokens: Token[]) {
-    const tokens = [..._tokens]
+    const tokens = trimTokens(_tokens)
 
-    while (tokens[0].type === TOKEN_TYPE.NEW_LINE) {
-        tokens.shift()
+    if (tokens.length === 0) {
+        return
     }
 
     let currentDepth = 0
@@ -63,19 +63,26 @@ export function assertIndentValidity(_tokens: Token[]) {
     }
 }
 
+function trimTokens(_tokens: Token[]) {
+    const tokens = [..._tokens]
+
+    while (tokens.length && tokens[0].type === TOKEN_TYPE.NEW_LINE) {
+        tokens.shift()
+    }
+
+    while (
+        tokens.length &&
+        [TOKEN_TYPE.NEW_LINE, TOKEN_TYPE.SPACE, TOKEN_TYPE.INDENT].includes(
+            tokens[tokens.length - 1].type,
+        )
+    ) {
+        tokens.pop()
+    }
+
+    return tokens
+}
+
 function isCodeEnded(leftTokens: Token[]) {
-    // const tokens = [...leftTokens]
-
-    // while (
-    //     [TOKEN_TYPE.NEW_LINE, TOKEN_TYPE.SPACE, TOKEN_TYPE.INDENT].includes(
-    //         tokens[0].type,
-    //     )
-    // ) {
-    //     tokens.shift()
-    // }
-
-    // return tokens.length === 0
-
     for (let i = 0; i < leftTokens.length; i++) {
         const type = leftTokens[i].type
 

--- a/src/prepare/tokenize/index.ts
+++ b/src/prepare/tokenize/index.ts
@@ -1,8 +1,7 @@
-import { UnexpectedCharError } from '../../error/prepare.ts'
 import { NotAcceptableSignal } from './signal.ts'
 import { RULES } from './rules.ts'
 
-import type { Token } from './token.ts'
+import { TOKEN_TYPE, type Token } from './token.ts'
 
 class Tokenizer {
     private tokens: Token[] = []
@@ -80,16 +79,17 @@ class Tokenizer {
                 continue
             }
 
-            throw new UnexpectedCharError({
-                resource: {
-                    char: this.code.slice(0, 5).join(''),
-                    parts: '코드',
-                },
+            this.tokens.push({
+                type: TOKEN_TYPE.UNKNOWN,
                 position: {
                     column: this.column,
                     line: this.line,
                 },
+                value: char,
             })
+
+            this.code.shift()
+            this.column++
         }
 
         return this.tokens

--- a/src/prepare/tokenize/index.ts
+++ b/src/prepare/tokenize/index.ts
@@ -1,11 +1,8 @@
-import { mergeArgumentBranchingTokens } from './merge-argument-branching-tokens.ts'
 import { UnexpectedCharError } from '../../error/prepare.ts'
 import { NotAcceptableSignal } from './signal.ts'
 import { RULES } from './rules.ts'
 
 import type { Token } from './token.ts'
-import { getFunctionDeclareRanges } from '../../util/get-function-declare-ranges.ts'
-import { assertIndentValidity } from './indent-validity.ts'
 
 class Tokenizer {
     private tokens: Token[] = []
@@ -109,12 +106,7 @@ class Tokenizer {
 
 export function tokenize(text: string): Token[] {
     const tokens = new Tokenizer(text).tokenize()
-    const functionDeclareRanges = getFunctionDeclareRanges(tokens)
-    const merged = mergeArgumentBranchingTokens(tokens, functionDeclareRanges)
-
-    assertIndentValidity(merged)
-
-    return merged
+    return tokens
 }
 
 function preprocess(code: string) {

--- a/src/prepare/tokenize/rules.ts
+++ b/src/prepare/tokenize/rules.ts
@@ -237,6 +237,10 @@ export const RULES: {
             let value = quote
 
             while (view() !== quote) {
+                if (view() === undefined) {
+                    return value
+                }
+
                 value += shift()!
             }
 

--- a/src/prepare/tokenize/rules.ts
+++ b/src/prepare/tokenize/rules.ts
@@ -288,13 +288,6 @@ export const RULES: {
             return value
         },
     },
-    {
-        type: TOKEN_TYPE.UNKNOWN,
-        starter: /./,
-        parse: (_, shift) => {
-            return shift()!
-        },
-    },
 ]
 
 function getAppliableOperators(prefix: string) {

--- a/src/prepare/tokenize/rules.ts
+++ b/src/prepare/tokenize/rules.ts
@@ -288,6 +288,13 @@ export const RULES: {
             return value
         },
     },
+    {
+        type: TOKEN_TYPE.UNKNOWN,
+        starter: /./,
+        parse: (_, shift) => {
+            return shift()!
+        },
+    },
 ]
 
 function getAppliableOperators(prefix: string) {

--- a/src/prepare/tokenize/token.ts
+++ b/src/prepare/tokenize/token.ts
@@ -17,6 +17,7 @@ export enum TOKEN_TYPE {
     COLON = 'COLON',
     LINE_COMMENT = 'LINE_COMMENT',
     MENTION = 'MENTION',
+    UNKNOWN = 'UNKNOWN',
 }
 
 export interface Token {
@@ -42,4 +43,5 @@ export const TOKEN_TYPE_TO_TEXT: Record<TOKEN_TYPE, string> = {
     [TOKEN_TYPE.COLON]: '쌍점',
     [TOKEN_TYPE.LINE_COMMENT]: '주석',
     [TOKEN_TYPE.MENTION]: '불러오기',
+    [TOKEN_TYPE.UNKNOWN]: '알 수 없음',
 }

--- a/src/type/code-file.ts
+++ b/src/type/code-file.ts
@@ -1,4 +1,6 @@
+import { mergeArgumentBranchingTokens } from '../prepare/lex/merge-argument-branching-tokens.ts'
 import { getFunctionDeclareRanges } from '../util/get-function-declare-ranges.ts'
+import { assertIndentValidity } from '../prepare/lex/indent-validity.ts'
 import { executer, type ExecuteResult } from '../executer/index.ts'
 import { tokenize } from '../prepare/tokenize/index.ts'
 import { parse } from '../prepare/parse/index.ts'
@@ -29,11 +31,22 @@ export class CodeFile {
     }
 
     public get tokens(): Token[] {
-        if (this.tokenized === null) {
-            this.tokenized = tokenize(this.text)
+        if (this.tokenized) {
+            return this.tokenized
         }
 
-        return this.tokenized
+        const tokens = tokenize(this.text)
+
+        const functionDeclareRanges = getFunctionDeclareRanges(tokens)
+        const merged = mergeArgumentBranchingTokens(
+            tokens,
+            functionDeclareRanges,
+        )
+
+        assertIndentValidity(merged)
+        this.tokenized = merged
+
+        return merged
     }
 
     public get ast(): Block {

--- a/src/type/code-file.ts
+++ b/src/type/code-file.ts
@@ -30,7 +30,7 @@ export class CodeFile {
 
     public get tokens(): Token[] {
         if (this.tokenized === null) {
-            this.tokenized = tokenize(this)
+            this.tokenized = tokenize(this.text)
         }
 
         return this.tokenized


### PR DESCRIPTION
# 문제

올바르지 않은 코드가 주어질 때 Tokenizer 함수가 오류를 냄. 프론트엔드에서 코드 하이라이팅을 위해 Tokenizer 함수를 사용하는데, 타이핑중인 코드가 문법적으로 완벽하지 않기에 하이라이팅에 실패함.

# 해결 방안

- Tokenizer 함수에서 담당하던 일부 문법 검사(함수 정의 헤더, 인덴트 유효성)를 lexing 단계로 분리하기
- 파싱에 실패한 문자는 UNKNOWN 토큰으로 처리하기