### PR TITLE
feat: add support for NotExpression in colorization

### DIFF
--- a/core/deno.json
+++ b/core/deno.json
@@ -6,5 +6,5 @@
   },
   "name": "@dalbit-yaksok/core",
   "exports": "./mod.ts",
-  "version": "1.0.0-nightly+20250316d"
+  "version": "1.1.1"
 }

--- a/core/deno.json
+++ b/core/deno.json
@@ -6,5 +6,5 @@
   },
   "name": "@dalbit-yaksok/core",
   "exports": "./mod.ts",
-  "version": "1.0.0-nightly+20250316c"
+  "version": "1.0.0-nightly+20250316d"
 }

--- a/deno.json
+++ b/deno.json
@@ -22,7 +22,7 @@
         "test",
         "monaco-language-provider"
     ],
-    "version": "1.0.0-nightly+20250316d",
+    "version": "1.1.1",
     "tasks": {
         "apply-version": "deno run --allow-read --allow-write apply-version.ts",
         "publish": "deno task --recursive test && deno publish --allow-dirty",

--- a/deno.json
+++ b/deno.json
@@ -22,7 +22,7 @@
         "test",
         "monaco-language-provider"
     ],
-    "version": "1.0.0-nightly+20250316c",
+    "version": "1.0.0-nightly+20250316d",
     "tasks": {
         "apply-version": "deno run --allow-read --allow-write apply-version.ts",
         "publish": "deno task --recursive test && deno publish --allow-dirty",

--- a/monaco-language-provider/ast-to-colorize/index.ts
+++ b/monaco-language-provider/ast-to-colorize/index.ts
@@ -19,6 +19,7 @@ import {
     TOKEN_TYPE,
     ValueWithParenthesis,
     ReturnStatement,
+    NotExpression,
 } from '@dalbit-yaksok/core'
 import { ColorPart } from '../type.ts'
 import { SCOPE } from './scope.ts'
@@ -111,6 +112,10 @@ function node(node: Node): ColorPart[] {
 
     if (node instanceof EOL) {
         return []
+    }
+
+    if (node instanceof NotExpression) {
+        return visitNotExpression(node)
     }
 
     console.log('Unknown node:', node)
@@ -395,15 +400,24 @@ function setToIndex(current: SetToIndex): ColorPart[] {
 function visitReturn(current: ReturnStatement): ColorPart[] {
     const lastTokenPosition = current.tokens[current.tokens.length - 1].position
 
-    const colorParts: ColorPart[] = [
-        ...(current.value ? node(current.value) : []),
+    const valueColorParts = current.value ? node(current.value) : []
+    const keywordColorPart: ColorPart[] = [
         {
             position: lastTokenPosition,
             scopes: SCOPE.KEYWORD,
         },
     ]
 
-    return colorParts
+    return valueColorParts.concat(keywordColorPart)
+}
+
+function visitNotExpression(current: NotExpression): ColorPart[] {
+    return [
+        {
+            position: current.tokens[0].position,
+            scopes: SCOPE.OPERATOR,
+        } as ColorPart,
+    ].concat(node(current.value))
 }
 
 export { node as nodeToColorTokens }

--- a/monaco-language-provider/deno.json
+++ b/monaco-language-provider/deno.json
@@ -4,5 +4,5 @@
   },
   "name": "@dalbit-yaksok/monaco-language-provider",
   "exports": "./mod.ts",
-  "version": "1.0.0-nightly+20250316d"
+  "version": "1.1.1"
 }

--- a/monaco-language-provider/deno.json
+++ b/monaco-language-provider/deno.json
@@ -4,5 +4,5 @@
   },
   "name": "@dalbit-yaksok/monaco-language-provider",
   "exports": "./mod.ts",
-  "version": "1.0.0-nightly+20250316c"
+  "version": "1.0.0-nightly+20250316d"
 }

--- a/quickjs/deno.json
+++ b/quickjs/deno.json
@@ -9,5 +9,5 @@
     "check-deploy": "deno publish --dry-run --allow-dirty",
     "test": "deno test --quiet --allow-net --allow-read --parallel & deno lint & deno task check-deploy"
   },
-  "version": "1.0.0-nightly+20250316c"
+  "version": "1.0.0-nightly+20250316d"
 }

--- a/quickjs/deno.json
+++ b/quickjs/deno.json
@@ -9,5 +9,5 @@
     "check-deploy": "deno publish --dry-run --allow-dirty",
     "test": "deno test --quiet --allow-net --allow-read --parallel & deno lint & deno task check-deploy"
   },
-  "version": "1.0.0-nightly+20250316d"
+  "version": "1.1.1"
 }


### PR DESCRIPTION
Monaco Language Provider의 `ast-to-colorize` 함수에 `NotExpression` 지원을 추가합니다