### PR TITLE
Skip no break or return validate

### DIFF
--- a/core/constant/feature-flags.ts
+++ b/core/constant/feature-flags.ts
@@ -3,6 +3,10 @@ export enum FEATURE_FLAG {
      * 약속 호출에서 신문법 사용을 강제합니다. 신문법에서는 인자에 괄호를 사용해야만 합니다. 예를 들어, `("치킨")먹기`는 가능하지만 `"치킨" 먹기`는 불가능합니다.
      */
     FUTURE_FUNCTION_INVOKE_SYNTAX = 'future-function-invoke-syntax',
+    /**
+     * "반복" 구문 내에 멈춤 코드(약속 그만, 반복 그만, 돌려주기)가 없어도 유효성 검사에 실패하지 않습니다.
+     */
+    SKIP_VALIDATE_BREAK_OR_RETURN_IN_LOOP = 'skip-validate-break-or-return-in-loop',
 }
 
 export type EnabledFlags = Partial<Record<FEATURE_FLAG, boolean>>

--- a/core/node/loop.ts
+++ b/core/node/loop.ts
@@ -1,11 +1,11 @@
 import { BreakSignal } from '../executer/signals.ts'
 import { Executable } from './base.ts'
 
-import { TOKEN_TYPE, type Token } from '../prepare/tokenize/token.ts'
-import type { Scope } from '../executer/scope.ts'
-import type { Block } from './block.ts'
 import { YaksokError } from '../error/common.ts'
 import { NoBreakOrReturnError } from '../error/loop.ts'
+import type { Scope } from '../executer/scope.ts'
+import { TOKEN_TYPE, type Token } from '../prepare/tokenize/token.ts'
+import type { Block } from './block.ts'
 
 export class Loop extends Executable {
     static override friendlyName = '반복'
@@ -27,7 +27,7 @@ export class Loop extends Executable {
     }
 
     override validate(scope: Scope): YaksokError[] {
-        const noBreakOrReturnError = hasBreakOrReturn(this)
+        const noBreakOrReturnError = hasBreakOrReturn(this, scope)
             ? []
             : [
                   new NoBreakOrReturnError({
@@ -57,7 +57,14 @@ export class Break extends Executable {
     }
 }
 
-function hasBreakOrReturn(node: Loop) {
+function hasBreakOrReturn(node: Loop, scope: Scope): boolean {
+    const hasSkipValidateFlag =
+        scope.codeFile?.runtime?.flags['skip-validate-break-or-return-in-loop']
+
+    if (hasSkipValidateFlag) {
+        return true
+    }
+
     return node.tokens.some((token, index) => {
         if (
             token.type === TOKEN_TYPE.IDENTIFIER &&

--- a/runtest.ts
+++ b/runtest.ts
@@ -6,26 +6,16 @@ const quickjs = new QuickJS({
 })
 
 await quickjs.init()
-
 await yaksok(
     `
-번역(JavaScript), (arr) (n)번째 값 제거
-***
-return [...arr.slice(0, n), ...arr.slice(n + 1)];
-***
-
-배열 = [1, 2, 3, 4, 5]
-배열 보여주기
-배열[2] 보여주기
-
-삭제된거 = 배열 2번째 값 제거
-삭제된거 보여주기
-삭제된거[2] 보여주기
-배열 보여주기
-`,
+순서 = 0
+반복
+    순서 = 순서 + 1
+    만약 순서 == 3 이면
+        [] / 2 보여주기`,
     {
-        runFFI(_, code, args) {
-            return quickjs.run(code, args)
+        flags: {
+            'skip-validate-break-or-return-in-loop': true,
         },
     },
 )

--- a/test/errors/loop.test.ts
+++ b/test/errors/loop.test.ts
@@ -1,20 +1,21 @@
 import { assertIsError, unreachable } from '@std/assert'
-import { yaksok } from '../../core/mod.ts'
+import { YaksokError } from '../../core/error/common.ts'
 import {
-    InvalidTypeForOperatorError,
     IndexOutOfRangeError,
+    InvalidTypeForOperatorError,
+    ListIndexMustBeGreaterOrEqualThan0Error,
     ListIndexTypeError,
     NotEnumerableValueForListLoopError,
+    RangeEndMustBeIntegerError,
     RangeEndMustBeNumberError,
+    RangeStartMustBeIntegerError,
     RangeStartMustBeLessThanEndError,
     RangeStartMustBeNumberError,
-    RangeStartMustBeIntegerError,
-    RangeEndMustBeIntegerError,
     TargetIsNotIndexedValueError,
-    ListIndexMustBeGreaterOrEqualThan0Error,
 } from '../../core/error/index.ts'
-import { ErrorGroups } from '../../core/error/validation.ts'
 import { NoBreakOrReturnError } from '../../core/error/loop.ts'
+import { ErrorGroups } from '../../core/error/validation.ts'
+import { yaksok } from '../../core/mod.ts'
 
 Deno.test('Error raised in loop', async () => {
     try {
@@ -182,5 +183,27 @@ Deno.test('No break or return in loop', async () => {
     } catch (e) {
         assertIsError(e, ErrorGroups)
         assertIsError(e.errors.get('main')![0], NoBreakOrReturnError)
+    }
+})
+
+Deno.test('No break or return in loop', async () => {
+    try {
+        await yaksok(
+            `
+순서 = 0
+반복
+    순서 = 순서 + 1
+    만약 순서 == 3 이면
+        [] / 2 보여주기`,
+            {
+                flags: {
+                    'skip-validate-break-or-return-in-loop': true,
+                },
+            },
+        )
+        unreachable()
+    } catch (e) {
+        assertIsError(e, YaksokError)
+        assertIsError(e, InvalidTypeForOperatorError)
     }
 })


### PR DESCRIPTION
'skip-validate-break-or-return-in-loop' Feature Flag를 이용하여 반복 내에 멈춤코드가 없는지 검사하는 과정을 건너뛸 수 있습니다.

```
await yaksok(
    `
순서 = 0
반복
    순서 = 순서 + 1
    만약 순서 == 3 이면
        [] / 2 보여주기`,
    {
        flags: {
            'skip-validate-break-or-return-in-loop': true,
        },
    },
)
```