### PR TITLE
`executionDelay` in CodeFile level & More information to runningCode event

### DIFF
--- a/core/constant/feature-flags.ts
+++ b/core/constant/feature-flags.ts
@@ -8,6 +8,11 @@ export enum FEATURE_FLAG {
      * 대괄호를 우선하여 파싱하지 않습니다. 파싱 오류가 발생할 경우 이 옵션이 도움이 될 수 있습니다.
      */
     DISABLE_BRACKET_FIRST_PARSING = 'disable-bracket-first-parsing',
+
+    /**
+     * 수식 연산에 Execution Delay를 적용하지 않습니다. 활성화할 시 수식에서는 runningCode 이벤트도 발생하지 않습니다.
+     */
+    DISABLE_OPERAND_EXECUTION_DELAY = 'disable-operand-execution-delay',
 }
 
 export type EnabledFlags = Partial<Record<FEATURE_FLAG, boolean>>

--- a/core/deno.json
+++ b/core/deno.json
@@ -6,5 +6,5 @@
   },
   "name": "@dalbit-yaksok/core",
   "exports": "./mod.ts",
-  "version": "2.2.2"
+  "version": "2.2.3"
 }

--- a/core/deno.json
+++ b/core/deno.json
@@ -6,5 +6,5 @@
   },
   "name": "@dalbit-yaksok/core",
   "exports": "./mod.ts",
-  "version": "2.2.3"
+  "version": "3.0.0-RC.1"
 }

--- a/core/node/base.ts
+++ b/core/node/base.ts
@@ -1,11 +1,11 @@
-import { assertValidReturnValue } from '../util/assert-valid-return-value.ts'
 import { NotDefinedIdentifierError } from '../error/variable.ts'
+import { assertValidReturnValue } from '../util/assert-valid-return-value.ts'
 
-import type { Token } from '../prepare/tokenize/token.ts'
-import type { ValueType } from '../value/base.ts'
-import type { Scope } from '../executer/scope.ts'
 import { YaksokError } from '../error/common.ts'
 import { NotExecutableNodeError } from '../error/unknown-node.ts'
+import type { Scope } from '../executer/scope.ts'
+import type { Token } from '../prepare/tokenize/token.ts'
+import type { ValueType } from '../value/base.ts'
 
 export class Node {
     [key: string]: unknown
@@ -38,6 +38,43 @@ export class Executable extends Node {
 
     override toPrint(): string {
         throw new Error(`${this.constructor.name} has no toPrint method`)
+    }
+
+    protected async onRunChild(scope: Scope, childTokens: Token[]) {
+        const executionDelay = scope.codeFile?.session?.executionDelay
+
+        const isMainContext =
+            scope.codeFile?.session?.entrypoint === scope.codeFile
+        const isBaseContext =
+            scope.codeFile?.fileName ===
+            scope.codeFile?.session?.BASE_CONTEXT_SYMBOL
+
+        if (executionDelay && isMainContext && !isBaseContext) {
+            await new Promise((r) => setTimeout(r, executionDelay))
+        }
+
+        if (childTokens.length) {
+            this.reportRunningCode(childTokens, scope)
+        }
+    }
+
+    private reportRunningCode(childTokens: Token[], scope: Scope) {
+        const startPosition = childTokens[0].position
+        const endToken = childTokens[childTokens.length - 1]
+        const endPosition = {
+            line: endToken.position.line,
+            column: endToken.position.column + endToken.value.length,
+        }
+
+        scope.codeFile?.session?.pubsub.pub('runningCode', [
+            {
+                line: startPosition.line,
+                column: startPosition.column,
+            },
+            endPosition,
+            scope,
+            childTokens,
+        ])
     }
 }
 

--- a/core/node/base.ts
+++ b/core/node/base.ts
@@ -41,15 +41,9 @@ export class Executable extends Node {
     }
 
     protected async onRunChild(scope: Scope, childTokens: Token[]) {
-        const executionDelay = scope.codeFile?.session?.executionDelay
+        const executionDelay = scope.codeFile?.executionDelay
 
-        const isMainContext =
-            scope.codeFile?.session?.entrypoint === scope.codeFile
-        const isBaseContext =
-            scope.codeFile?.fileName ===
-            scope.codeFile?.session?.BASE_CONTEXT_SYMBOL
-
-        if (executionDelay && isMainContext && !isBaseContext) {
+        if (executionDelay) {
             await new Promise((r) => setTimeout(r, executionDelay))
         }
 

--- a/core/node/block.ts
+++ b/core/node/block.ts
@@ -36,7 +36,7 @@ export class Block extends Executable {
                     await new Promise((r) => setTimeout(r, executionDelay))
                 }
 
-                if (child.tokens.length && isMainContext && !isBaseContext) {
+                if (child.tokens.length) {
                     this.reportRunningCode(child, scope)
                 }
 
@@ -70,8 +70,12 @@ export class Block extends Executable {
             column: endToken.position.column + endToken.value.length,
         }
         scope.codeFile?.session?.pubsub.pub('runningCode', [
-            startPosition,
+            {
+                line: startPosition.line,
+                column: startPosition.column,
+            },
             endPosition,
+            scope,
         ])
     }
 }

--- a/core/prepare/tokenize/index.ts
+++ b/core/prepare/tokenize/index.ts
@@ -76,8 +76,8 @@ class Tokenizer {
                             type: rule.type,
                             value: value,
                             position: {
-                                column: initialColumnForToken,
                                 line: initialLineForToken,
+                                column: initialColumnForToken,
                             },
                         })
 
@@ -126,8 +126,8 @@ class Tokenizer {
             this.tokens.push({
                 type: TOKEN_TYPE.UNKNOWN,
                 position: {
-                    column: this.column,
                     line: this.line,
+                    column: this.column,
                 },
                 value: char,
             })

--- a/core/session/session-config.ts
+++ b/core/session/session-config.ts
@@ -1,5 +1,6 @@
 import type { EnabledFlags } from '../constant/feature-flags.ts'
 import type { Scope } from '../executer/scope.ts'
+import type { Token } from '../prepare/tokenize/token.ts'
 import type { Position } from '../type/position.ts'
 
 /**
@@ -69,7 +70,12 @@ export type Events = {
      * @param end
      * @returns
      */
-    runningCode: (start: Position, end: Position, scope: Scope) => void
+    runningCode: (
+        start: Position,
+        end: Position,
+        scope: Scope,
+        tokens: Token[],
+    ) => void
 }
 
 export const DEFAULT_SESSION_CONFIG: SessionConfig = {

--- a/core/session/session-config.ts
+++ b/core/session/session-config.ts
@@ -13,7 +13,6 @@ import type { Position } from '../type/position.ts'
  *    stdout: console.log,
  *    stderr: console.error,
  *    entryPoint: 'main',
- *    executionDelay: 0,
  *    flags: {},
  *    events: {
  *        runningCode: (start, end) => {

--- a/core/session/session-config.ts
+++ b/core/session/session-config.ts
@@ -45,11 +45,6 @@ export interface SessionConfig {
      */
     entryPoint: string
     /**
-     * 각 라인의 실행을 지연시킬 시간 (밀리초). 코드 시각화 목적으로 사용합니다.
-     * @default 0
-     */
-    executionDelay: number
-    /**
      * 활성화할 기능 플래그
      */
     flags: EnabledFlags
@@ -83,7 +78,6 @@ export const DEFAULT_SESSION_CONFIG: SessionConfig = {
     stderr: console.error,
     entryPoint: 'main',
     flags: {},
-    executionDelay: 0,
     events: {
         runningCode: () => {},
     },

--- a/core/session/session-config.ts
+++ b/core/session/session-config.ts
@@ -1,4 +1,5 @@
 import type { EnabledFlags } from '../constant/feature-flags.ts'
+import type { Scope } from '../executer/scope.ts'
 import type { Position } from '../type/position.ts'
 
 /**
@@ -68,7 +69,7 @@ export type Events = {
      * @param end
      * @returns
      */
-    runningCode: (start: Position, end: Position) => void
+    runningCode: (start: Position, end: Position, scope: Scope) => void
 }
 
 export const DEFAULT_SESSION_CONFIG: SessionConfig = {

--- a/core/type/code-file.ts
+++ b/core/type/code-file.ts
@@ -29,6 +29,7 @@ export class CodeFile {
 
     public ranScope: Scope | null = null
     public session: YaksokSession | null = null
+    public executionDelay: number | null = null
 
     constructor(public text: string, public fileName: string | symbol) {}
 
@@ -199,4 +200,8 @@ export class CodeFile {
 
         return result
     }
+}
+
+export interface CodeFileConfig {
+    executionDelay?: number
 }

--- a/deno.json
+++ b/deno.json
@@ -18,7 +18,7 @@
         "test",
         "monaco-language-provider"
     ],
-    "version": "2.2.3",
+    "version": "3.0.0-RC.1",
     "tasks": {
         "apply-version": "deno run --allow-read --allow-write apply-version.ts",
         "publish": "deno task apply-version && deno task --recursive test && deno publish --allow-dirty",

--- a/deno.json
+++ b/deno.json
@@ -18,7 +18,7 @@
         "test",
         "monaco-language-provider"
     ],
-    "version": "2.2.2",
+    "version": "2.2.3",
     "tasks": {
         "apply-version": "deno run --allow-read --allow-write apply-version.ts",
         "publish": "deno task apply-version && deno task --recursive test && deno publish --allow-dirty",

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -12,15 +12,6 @@
 
 .running-code {
     background-color: var(--vp-c-tip-soft);
-    animation: appear 0.3s;
     padding: 0.5em;
-}
-
-@keyframes appear {
-    from {
-        opacity: 0;
-    }
-    to {
-        opacity: 1;
-    }
+    border-bottom: 1px solid var(--vp-c-border);
 }

--- a/docs/_/code-runner/index.vue
+++ b/docs/_/code-runner/index.vue
@@ -105,7 +105,6 @@ async function runCode() {
             stderr: (output) => {
                 stdout.value = [...stdout.value, ansiToHtml(output)]
             },
-            executionDelay: 400,
             events: {
                 runningCode(start, end, scope, tokens) {
                     const range = new monaco!.Range(
@@ -136,7 +135,9 @@ async function runCode() {
             },
         })
 
-        session.addModule('main', code.value)
+        session.addModule('main', code.value, {
+            executionDelay: 400,
+        })
 
         console.log(await session.runModule('main'))
     } catch (error) {

--- a/docs/_/code-runner/index.vue
+++ b/docs/_/code-runner/index.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
-import { onMounted, ref, useTemplateRef, watch } from 'vue'
-import type { editor, Range } from 'monaco-editor'
+import { YaksokSession } from '@dalbit-yaksok/core'
 import AnsiCode from 'ansi-to-html'
-
-import { yaksok } from '@dalbit-yaksok/core'
+import type { editor } from 'monaco-editor'
+import { onMounted, ref, useTemplateRef, watch } from 'vue'
 
 import { loadMonaco } from './load-monaco'
 
@@ -99,18 +98,16 @@ async function runCode() {
     stdout.value = []
 
     try {
-        await yaksok(code.value, {
+        const session = new YaksokSession({
             stdout: (output) => {
                 stdout.value = [...stdout.value, output]
             },
             stderr: (output) => {
-                console.log({ output })
                 stdout.value = [...stdout.value, ansiToHtml(output)]
             },
-            executionDelay: 500,
+            executionDelay: 400,
             events: {
-                runningCode(start, end) {
-                    console.log(start, end)
+                runningCode(start, end, scope, tokens) {
                     const range = new monaco!.Range(
                         start.line,
                         start.column,
@@ -138,6 +135,10 @@ async function runCode() {
                 },
             },
         })
+
+        session.addModule('main', code.value)
+
+        console.log(await session.runModule('main'))
     } catch (error) {
         console.error(error)
     }
@@ -145,7 +146,7 @@ async function runCode() {
     if (prevDecorations) {
         setTimeout(() => {
             ;(prevDecorations as editor.IEditorDecorationsCollection).clear()
-        }, 300)
+        }, 400)
     }
 }
 

--- a/docs/_/create-docs.ts
+++ b/docs/_/create-docs.ts
@@ -29,9 +29,9 @@ if (!isWatch) {
 console.log('Waiting for file changes...')
 
 const watcher = Deno.watchFs(
-    ['\\..\\..\\core', '\\..\\..\\monaco-language-provider'].map(
-        (path) => import.meta.dirname + path,
-        // (path) => new URL(path, import.meta.url).pathname,
+    ['.\\..\\..\\core', '.\\..\\..\\monaco-language-provider'].map(
+        // (path) => import.meta.dirname + path,
+        (path) => new URL(path, import.meta.url).pathname,
     ),
     {
         recursive: true,

--- a/docs/guide/core/04.session-and-codefile.md
+++ b/docs/guide/core/04.session-and-codefile.md
@@ -26,7 +26,7 @@ YaksokSession은 '달빛 약속' 코드의 실행 생명주기를 총괄하는 �
 YaksokSession의 주요 역할은 다음과 같습니다.
 
 1.  **CodeFile 모듈 관리**: `addModule(moduleName, code)` 메소드를 통해 CodeFile 인스턴스를 생성하고, 이를 `files` 맵에 모듈 이름(`moduleName`)을 키로 저장하여 관리합니다. `runModule(moduleName)`을 호출하면 해당 모듈을 찾아 실행합니다.
-2.  **실행 환경 설정**: `SessionConfig`를 통해 `stdout` (출력), `stderr` (오류 출력), `executionDelay` (실행 지연), `flags` (기능 플래그), `events` (이벤트 구독), `signal` (실행 중단 시그널) 등 세션의 동작을 사용자화하는 다양한 설정을 관리합니다.
+2.  **실행 환경 설정**: `SessionConfig`를 통해 `stdout` (출력), `stderr` (오류 출력), `flags` (기능 플래그), `events` (이벤트 구독), `signal` (실행 중단 시그널) 등 세션의 동작을 사용자화하는 다양한 설정을 관리합니다.
 3.  **FFI(Foreign Function Interface) 확장**: `extend(extension)` 메소드를 통해 외부 함수(FFI) 런타임을 추가하고 관리할 수 있습니다. 이는 '달빛 약속'이 JavaScript/TypeScript 환경의 기능을 활용할 수 있도록 하는 중요한 확장 지점입니다.
 4.  **기본 컨텍스트(`baseContext`) 제공**: `setBaseContext`를 통해 모든 CodeFile이 공유할 수 있는 전역 스코프와 같은 기본 컨텍스트를 설정할 수 있습니다. 이는 파일 간의 변수 및 함수 공유를 가능하게 합니다.
 5.  **실행 흐름 제어**: `runModule` 메소드는 CodeFile.run()을 호출하여 실제 실행을 시작하고, 실행 중 발생하는 오류나 `AbortedSessionSignal`과 같은 특별한 시그널을 처리하여 프로그램의 흐름을 제어합니다.

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,13 +34,13 @@ features:
 
 <script setup>
 
-const DEFAULT_CODE = `약속, 키가 (키)cm이고 몸무게가 (몸무게)일 때 비만도
+const DEFAULT_CODE = `"달빛약속에 오신걸 환영합니다" 보여주기
+약속, 키가 (키)cm이고 몸무게가 (몸무게)일 때 비만도
     몸무게 / (키 / 100 * 키 / 100) 반환하기
 
 비만도 = 키가 (170)cm이고 몸무게가 (70)일 때 비만도
 
 비만도 보여주기
-비만도 보여줄까말까
 `
 
 const codeFromUrl = (globalThis.location && new URL(globalThis.location.href).searchParams.get('code')) || DEFAULT_CODE

--- a/docs/library/5. code-location-tracking.md
+++ b/docs/library/5. code-location-tracking.md
@@ -1,5 +1,5 @@
 ---
-title: "5. 현재 실행중인 코드의 위치 가져오기(코드 실행 속도 늦추기)"
+title: '5. 현재 실행중인 코드의 위치 가져오기(코드 실행 속도 늦추기)'
 ---
 
 # 현재 실행중인 코드의 위치 가져오기(코드 실행 속도 늦추기)
@@ -12,16 +12,25 @@ title: "5. 현재 실행중인 코드의 위치 가져오기(코드 실행 속�
 
 ## 코드 실행 속도 늦추기
 
-프로그램이 실행되는 속도는 매우 빠르기에, 코드 실행 과정을 시각화하기 위해서는 코드 실행 속도를 늦춰야 합니다. 이는 `sessionConfig` 객체의 `executionDelay` 속성을 사용하여 설정할 수 있습니다. `executionDelay` 속성은 코드 실행 속도를 늦추는 시간을 밀리초 단위로 설정합니다.
-
-[SessionConfig.executionDelay](/api/core/mod/interfaces/SessionConfig.html#executiondelay)
+프로그램이 실행되는 속도는 매우 빠르기에, 코드 실행 과정을 시각화하기 위해서는 코드 실행 속도를 늦춰야 합니다. 코드 실행 속도는 각 모듈별로 설정되며, addModule 메소드와 `executionDelay` 속성을 사용하여 지정합니다. `executionDelay` 속성은 코드 실행 속도를 늦추는 시간을 밀리초 단위로 설정합니다.
 
 ```ts
-import { yaksok, SessionConfig } from '@dalbit-yaksok/core'
+import { YaksokSession } from '@dalbit-yaksok/core'
 
-const sessionConfig: SessionConfig = {
-    executionDelay: 500,
-}
+const session = new YaksokSession()
+
+session.addModule(
+    'main',
+    `
+"안녕, 세상!" 보여주기
+"잠시 후에 출력됩니다" 보여주기
+`,
+    {
+        executionDelay: 500, // 코드 실행 속도를 500밀리초로 설정
+    },
+)
+
+await session.runModule('main')
 ```
 
 위 코드는 코드 실행 속도를 500밀리초로 설정합니다. 이제 코드는 500ms에 한 줄씩 실행됩니다.
@@ -36,28 +45,28 @@ const sessionConfig: SessionConfig = {
 import { yaksok, SessionConfig } from '@dalbit-yaksok/core'
 
 const sessionConfig: SessionConfig = {
-    executionDelay: 500,
     events: {
-        runningCode: (start, end) => {
-            console.log(start, end)
+        runningCode: (start, end, scope, tokens) => {
+            console.log(start, end, scope, tokens)
         },
     },
 }
 
-await yaksok(
+const session = new YaksokSession(sessionConfig)
+
+session.addModule(
+    'main',
     `
 1 보여주기
 1 + 2 보여주기
 `,
-    sessionConfig,
 )
 
+await session.runModule('main')
+
 /*
-콘솔 출력:
-{ line: 2, column: 1 } { line: 2, column: 7 }
-1
-{ line: 3, column: 1 } { line: 3, column: 11 }
-3
+{ line: 2, column: 1 } { line: 2, column: 7 } Scope { .. } [{ type: "NUMBER_LITERAL", value: "1" } ... ]
+{ line: 3, column: 1 } { line: 3, column: 11 } Scope { .. } [{ type: "NUMBER_LITERAL", value: "1" } ... ]
 */
 ```
 

--- a/monaco-language-provider/deno.json
+++ b/monaco-language-provider/deno.json
@@ -4,5 +4,5 @@
   },
   "name": "@dalbit-yaksok/monaco-language-provider",
   "exports": "./mod.ts",
-  "version": "2.2.2"
+  "version": "2.2.3"
 }

--- a/monaco-language-provider/deno.json
+++ b/monaco-language-provider/deno.json
@@ -4,5 +4,5 @@
   },
   "name": "@dalbit-yaksok/monaco-language-provider",
   "exports": "./mod.ts",
-  "version": "2.2.3"
+  "version": "3.0.0-RC.1"
 }

--- a/quickjs/deno.json
+++ b/quickjs/deno.json
@@ -9,5 +9,5 @@
     "check-deploy": "deno publish --dry-run --allow-dirty",
     "test": "deno test --quiet --allow-net --allow-read --parallel & deno lint & deno task check-deploy"
   },
-  "version": "2.2.2"
+  "version": "2.2.3"
 }

--- a/quickjs/deno.json
+++ b/quickjs/deno.json
@@ -9,5 +9,5 @@
     "check-deploy": "deno publish --dry-run --allow-dirty",
     "test": "deno test --quiet --allow-net --allow-read --parallel & deno lint & deno task check-deploy"
   },
-  "version": "2.2.3"
+  "version": "3.0.0-RC.1"
 }

--- a/runtest.ts
+++ b/runtest.ts
@@ -3,50 +3,29 @@ import { YaksokSession } from '@dalbit-yaksok/core'
 const session = new YaksokSession({
     executionDelay: 100,
     events: {
-        runningCode: (start, end, scope) => {
-            console.log(start, end, scope.codeFile?.fileName)
+        runningCode: (start, end, scope, tokens) => {
+            console.log(tokens.map((token) => token.value).join(' '))
         },
+    },
+    stdout(text) {
+        // console.log(text)
     },
 })
 
-session.addModules({
-    코레일: `
-약속, (차종)으로 (거리)km을 이동할 때 운임
-    만약 차종 == @차종 KTX이음 이면
-        만약 거리 <= 60 이면
-            8400 반환하기
-        아니면
-            8400 + (거리 - 60) * 140.2 반환하기
-
-    만약 차종 == @차종 무궁화호 이면
-        만약 거리 <= 40 이면
-            2600 반환하기
-        아니면
-            2600 + (거리 - 40) * 65 반환하기
-
-약속, 출발하기
-    "빵빵" 보여주기
-        `.trim(),
-    main: `
-"청량리부터 안동까지 KTX 이음을 타면" 보여주기
-(@코레일 (@차종 KTX이음)으로 (@역간거리 "청량리" 부터 "안동" 까지)km을 이동할 때 운임) + "원" 보여주기
-
-"판교부터 충주까지 무궁화호를 타면" 보여주기
-(@코레일 (@차종 무궁화호)으로 (@역간거리 "판교" 부터 "충주" 까지)km을 이동할 때 운임) + "원" 보여주기
-
-@코레일 출발하기
-        `,
-    역간거리: `
-약속, (역1)부터 (역2)까지
-    만약 역1 == "청량리" 이고 역2 == "안동" 이면
-        235.3 반환하기
-    만약 역1 == "판교" 이고 역2 == "충주" 이면
-        140.9 반환하기
-    `,
-    차종: `
-KTX이음 = "KTX-이음"
-무궁화호 = "무궁화호"
+session.addModule(
+    'main',
+    `
+"1 + 2 = " + (1 + 2) 보여주기
+"1 - 2 = " + (1 - 2) 보여주기
+"1 * 2 = " + (1 * 2) 보여주기
+"1 / 2 = " + (1 / 2) 보여주기
 `,
-})
+)
 
-await session.runModule('main')
+const startTime = Date.now()
+
+const result = await session.runModule('main')
+
+const endTime = Date.now()
+const duration = endTime - startTime
+console.log(`Execution finished in ${duration} ms`)

--- a/runtest.ts
+++ b/runtest.ts
@@ -1,11 +1,52 @@
-import { yaksok, YaksokSession } from '@dalbit-yaksok/core'
-import { QuickJS } from '@dalbit-yaksok/quickjs'
+import { YaksokSession } from '@dalbit-yaksok/core'
 
 const session = new YaksokSession({
-    stderr(message) {
-        console.error(message)
+    executionDelay: 100,
+    events: {
+        runningCode: (start, end, scope) => {
+            console.log(start, end, scope.codeFile?.fileName)
+        },
     },
 })
-await session.extend(new QuickJS())
-const result = await yaksok({})
-// console.log(result)
+
+session.addModules({
+    코레일: `
+약속, (차종)으로 (거리)km을 이동할 때 운임
+    만약 차종 == @차종 KTX이음 이면
+        만약 거리 <= 60 이면
+            8400 반환하기
+        아니면
+            8400 + (거리 - 60) * 140.2 반환하기
+
+    만약 차종 == @차종 무궁화호 이면
+        만약 거리 <= 40 이면
+            2600 반환하기
+        아니면
+            2600 + (거리 - 40) * 65 반환하기
+
+약속, 출발하기
+    "빵빵" 보여주기
+        `.trim(),
+    main: `
+"청량리부터 안동까지 KTX 이음을 타면" 보여주기
+(@코레일 (@차종 KTX이음)으로 (@역간거리 "청량리" 부터 "안동" 까지)km을 이동할 때 운임) + "원" 보여주기
+
+"판교부터 충주까지 무궁화호를 타면" 보여주기
+(@코레일 (@차종 무궁화호)으로 (@역간거리 "판교" 부터 "충주" 까지)km을 이동할 때 운임) + "원" 보여주기
+
+@코레일 출발하기
+        `,
+    역간거리: `
+약속, (역1)부터 (역2)까지
+    만약 역1 == "청량리" 이고 역2 == "안동" 이면
+        235.3 반환하기
+    만약 역1 == "판교" 이고 역2 == "충주" 이면
+        140.9 반환하기
+    `,
+    차종: `
+KTX이음 = "KTX-이음"
+무궁화호 = "무궁화호"
+`,
+})
+
+await session.runModule('main')

--- a/runtest.ts
+++ b/runtest.ts
@@ -1,7 +1,6 @@
 import { YaksokSession } from '@dalbit-yaksok/core'
 
 const session = new YaksokSession({
-    executionDelay: 100,
     events: {
         runningCode: (start, end, scope, tokens) => {
             console.log(tokens.map((token) => token.value).join(' '))
@@ -20,6 +19,9 @@ session.addModule(
 "1 * 2 = " + (1 * 2) 보여주기
 "1 / 2 = " + (1 / 2) 보여주기
 `,
+    {
+        executionDelay: 0, // No delay for testing
+    },
 )
 
 const startTime = Date.now()

--- a/test/execution-delay.test.ts
+++ b/test/execution-delay.test.ts
@@ -1,10 +1,4 @@
-import {
-    assert,
-    assertEquals,
-    assertGreater,
-    assertGreaterOrEqual,
-    assertLess,
-} from 'assert'
+import { assert, assertEquals, assertGreaterOrEqual, assertLess } from 'assert'
 import { YaksokSession } from '../core/mod.ts'
 
 Deno.test('Execution Delay in Main Context', async () => {
@@ -19,7 +13,6 @@ Deno.test('Execution Delay in Main Context', async () => {
     let output = ''
 
     const session = new YaksokSession({
-        executionDelay: 100,
         stdout(text) {
             output += text
         },
@@ -27,14 +20,16 @@ Deno.test('Execution Delay in Main Context', async () => {
 
     const startTime = Date.now()
 
-    session.addModule('main', code.main)
+    session.addModule('main', code.main, {
+        executionDelay: 100,
+    })
     await session.runModule('main')
 
     const endTime = Date.now()
     const duration = endTime - startTime
 
     assertEquals(output, `abc`)
-    assertGreater(duration, 300)
+    assertGreaterOrEqual(duration, 300)
     assertLess(duration, 350)
 })
 
@@ -54,7 +49,6 @@ Deno.test('Execution Delay with Imported File', async () => {
     let output = ''
 
     const session = new YaksokSession({
-        executionDelay: 100,
         stdout(text) {
             output += text
         },
@@ -62,7 +56,9 @@ Deno.test('Execution Delay with Imported File', async () => {
 
     const startTime = Date.now()
 
-    session.addModule('main', code.main)
+    session.addModule('main', code.main, {
+        executionDelay: 100,
+    })
     session.addModule('imported', code.imported)
 
     await session.runModule('main')
@@ -71,7 +67,7 @@ Deno.test('Execution Delay with Imported File', async () => {
     const duration = endTime - startTime
 
     assertEquals(output, 'abc')
-    assertGreater(duration, 300)
+    assertGreaterOrEqual(duration, 300)
     assertLess(duration, 350)
 })
 
@@ -98,13 +94,14 @@ Deno.test('Execution Delay with Nested Import', async () => {
     const startTime = Date.now()
 
     const session = new YaksokSession({
-        executionDelay: 100,
         stdout(text) {
             output += text
         },
     })
 
-    session.addModule('main', code.main)
+    session.addModule('main', code.main, {
+        executionDelay: 100,
+    })
     session.addModule('imported', code.imported)
     session.addModule('nested', code.nested)
 
@@ -121,7 +118,7 @@ Deno.test('Execution Delay with Nested Import', async () => {
 
     assertEquals(output, 'a!bc')
 
-    assertGreater(duration, 300)
+    assertGreaterOrEqual(duration, 300)
     assertLess(duration, 350)
 })
 
@@ -130,7 +127,6 @@ Deno.test('Execution Delay with Function Call', async () => {
     const startTime = Date.now()
 
     const session = new YaksokSession({
-        executionDelay: 100,
         stdout(text) {
             output += text
         },
@@ -147,6 +143,9 @@ Deno.test('Execution Delay with Function Call', async () => {
 " " 보여주기
 인사
         `,
+        {
+            executionDelay: 100,
+        },
     )
 
     const result = await session.runModule('main')
@@ -158,7 +157,7 @@ Deno.test('Execution Delay with Function Call', async () => {
     const duration = endTime - startTime
 
     assertEquals(output, '안녕 안녕')
-    assertGreater(duration, 800)
+    assertGreaterOrEqual(duration, 800)
     assertLess(duration, 850)
 })
 
@@ -168,12 +167,11 @@ Deno.test('Execution Delay with Base Context', async () => {
     let lastInstructionTime = new Date().getTime()
 
     const session = new YaksokSession({
-        executionDelay: 100,
         stdout(text) {
             assertEquals(text, expectedOutputs.shift())
             const currentTime = new Date().getTime()
             const timeDiff = currentTime - lastInstructionTime
-            assertGreater(timeDiff, 100)
+            assertGreaterOrEqual(timeDiff, 100)
             assertLess(timeDiff, 150)
             lastInstructionTime = currentTime
         },
@@ -187,7 +185,7 @@ Deno.test('Execution Delay with Base Context', async () => {
     const baseContextEndTime = Date.now()
     const baseContextDuration = baseContextEndTime - baseContextStartTime
 
-    assertGreater(baseContextDuration, 0)
+    assertGreaterOrEqual(baseContextDuration, 0)
     assertLess(baseContextDuration, 50)
 
     const mainContextStartTime = Date.now()
@@ -198,6 +196,9 @@ Deno.test('Execution Delay with Base Context', async () => {
 "그래요" 보여주기
 "그렇군요" 보여주기
 `,
+        {
+            executionDelay: 100,
+        },
     )
 
     await session.runModule('main')
@@ -205,7 +206,7 @@ Deno.test('Execution Delay with Base Context', async () => {
     const mainContextEndTime = Date.now()
     const mainContextDuration = mainContextEndTime - mainContextStartTime
 
-    assertGreater(mainContextDuration, 200)
+    assertGreaterOrEqual(mainContextDuration, 200)
     assertLess(mainContextDuration, 250)
 })
 
@@ -244,7 +245,6 @@ Deno.test('Execution Delay in Formula', async () => {
     let lastRun = new Date().getTime()
 
     const session = new YaksokSession({
-        executionDelay: 100,
         events: {
             runningCode(_start, _end, _scope, tokens) {
                 const runningCodeText = tokens
@@ -268,6 +268,9 @@ Deno.test('Execution Delay in Formula', async () => {
 "1 * 2 = " + (1 * 2) 보여주기
 "1 / 2 = " + (1 / 2) 보여주기
 `,
+        {
+            executionDelay: 100,
+        },
     )
 
     const startTime = Date.now()
@@ -281,6 +284,6 @@ Deno.test('Execution Delay in Formula', async () => {
 
     const duration = endTime - startTime
 
-    assertGreater(duration, 2800)
+    assertGreaterOrEqual(duration, 2800)
     assertLess(duration, 2900)
 })


### PR DESCRIPTION
- ExecutionDelay는 이제 Session이 아니라 CodeFile 단위로 관리됩니다.
- 수식의 연산 단계에서 ExecutionDelay가 적용됩니다. DISABLE_OPERAND_EXECUTION_DELAY 플래그로 비활성화 가능.
- runningCode 이벤트에 실행한 토큰, 스코프 정보도 함께 전달됩니다.