### PR TITLE
fix(core): avoid Object.prototype pollution for __proto__ variable name

### DIFF
--- a/core/executer/scope.ts
+++ b/core/executer/scope.ts
@@ -36,7 +36,7 @@ export class Scope {
             allowFunctionOverride?: boolean
         } = {},
     ) {
-        this.variables = config.initialVariable || {}
+        this.variables = config.initialVariable || Object.create(null)
 
         if (config.parent) {
             this.parent = config.parent


### PR DESCRIPTION
## Summary
\`Scope.variables\` was initialized as a plain object (\`{}\`), inheriting from \`Object.prototype\`. When user code declares a variable named \`__proto__\`, the resulting behavior breaks:

- \`name in this.variables\` returns \`true\` for \`__proto__\` regardless of whether the user set it (because \`Object.prototype\` has it)
- \`this.variables['__proto__']\` returns \`Object.prototype\` itself, not the user's \`ValueType\`
- Subsequent calls expecting \`ValueType\` methods (e.g. \`toPrint\`) throw \`TypeError: toPrint is not a function\`

This was reported downstream as horang-corp/magic-school-frontend#11.

## Change
\`\`\`diff
- this.variables = config.initialVariable || {}
+ this.variables = config.initialVariable || Object.create(null)
\`\`\`

Using \`Object.create(null)\` produces a prototype-less object. \`__proto__\` becomes a regular property name with no inherited semantics.

## Verification
Downstream (magic-school-frontend) confirmed via a \`pnpm patch\` of \`@jsr/dalbit-yaksok__core@6.0.4\` applying the same change — code playground accepts \`__proto__\` as a normal variable name. PR: horang-corp/magic-school-frontend#20.

## Risk
\`name in this.variables\` and \`this.variables[name]\` semantics for non-special names are unchanged — \`Object.create(null)\` objects support the same lookup/assignment operations. No other code in \`Scope\` relies on \`Object.prototype\` inheritance.