### PR TITLE
fix(core): 자기/순환 모듈 멘션의 무한재귀(스택오버플로) 방지

### DIFF
--- a/core/type/code-file.ts
+++ b/core/type/code-file.ts
@@ -33,6 +33,10 @@ export class CodeFile {
     public session: YaksokSession | null = null
     public executionDelay: number | null = null
 
+    // 자기/순환 참조 모듈의 무한재귀를 막기 위한 재진입 가드 (parse / validate).
+    private parsing: boolean = false
+    private validatingScopeInProgress: Scope | null = null
+
     constructor(
         public text: string,
         public fileName: string | symbol,
@@ -207,9 +211,22 @@ export class CodeFile {
      * 이 메서드는 `ast`나 `exportedRules` getter에서 필요할 때 호출됩니다.
      */
     private parse() {
-        const parseResult = parse(this)
-        this.parsed = parseResult.ast
-        this.exportedRulesCache = parseResult.exportedRules
+        // 자기/순환 참조 모듈은 parse 도중 mention 규칙 수집을 위해 같은 파일의
+        // exportedRules(=parse)를 다시 요구해 무한재귀(RangeError)했다. 이미 parse
+        // 중이면 순환 고리를 끊기 위해 빈 규칙으로 처리한다(자기 mention은 미해소).
+        if (this.parsing) {
+            this.exportedRulesCache ??= []
+            return
+        }
+
+        this.parsing = true
+        try {
+            const parseResult = parse(this)
+            this.parsed = parseResult.ast
+            this.exportedRulesCache = parseResult.exportedRules
+        } finally {
+            this.parsing = false
+        }
     }
 
     /**
@@ -217,6 +234,16 @@ export class CodeFile {
      * @returns 검사 과정에서 발견된 오류(`YaksokError`) 리스트와, 검사에 사용된 스코프를 반환합니다.
      */
     public validate(): { errors: YaksokError[]; validatingScope: Scope } {
+        // 자기/순환 참조 모듈(@자기 자신을 멘션)이 validate 도중 같은 파일의
+        // validate를 다시 호출하면 무한재귀(RangeError)가 난다. 이미 검증 중이면
+        // 진행 중인 스코프를 그대로 돌려주어 순환을 끊는다.
+        if (this.validatingScopeInProgress) {
+            return {
+                errors: [],
+                validatingScope: this.validatingScopeInProgress,
+            }
+        }
+
         if (this.validationScopes) {
             this.validationScopes.clear()
         }
@@ -224,6 +251,7 @@ export class CodeFile {
         const validatingScope = new Scope({
             codeFile: this,
         })
+        this.validatingScopeInProgress = validatingScope
 
         try {
             this.registerScope(validatingScope, this.ast)
@@ -248,6 +276,8 @@ export class CodeFile {
             }
 
             throw error
+        } finally {
+            this.validatingScopeInProgress = null
         }
     }
 

--- a/test/mention-scope.test.ts
+++ b/test/mention-scope.test.ts
@@ -46,3 +46,32 @@ Deno.test('MentionScope execute with non-YaksokError', async () => {
         `Expected finish but got ${result.reason}`,
     )
 })
+
+Deno.test(
+    'self-referential module does not infinitely recurse',
+    async () => {
+        // 모듈이 자기 이름을 @로 멘션하면(@자기참조) parse/validate가 같은 파일을
+        // 다시 요구하며 무한재귀(RangeError)했다. 재진입 가드로 순환을 끊어,
+        // 크래시 대신 정상적인 검증 오류로 종료되어야 한다. (runModule이 결과를
+        // 반환한다는 것 자체가 무한재귀가 없었다는 증거)
+        const session = new YaksokSession()
+
+        session.addModule(
+            '자기참조',
+            [
+                '약속, 인사',
+                '    "안녕" 보여주기',
+                '',
+                '약속, 부르기',
+                '    @자기참조 인사',
+            ].join('\n'),
+        )
+
+        const results = await session.runModule('자기참조')
+        const result = results.get('자기참조')!
+        assert(
+            result.reason === 'validation',
+            `Expected graceful validation result but got ${result.reason}`,
+        )
+    },
+)


### PR DESCRIPTION
## 요약

자기 자신을 `@`로 멘션하는 모듈(예: 이름이 `키링`인 모듈 안에 `@키링 …`)을 검증하면 `RangeError: Maximum call stack size exceeded`로 크래시했습니다. 재진입 가드로 순환을 끊습니다.

호랑 cellmode yaksok playground 프로덕션 `$exception`(PostHog)에서 출발해 규명했습니다. `animal-keyring` 패키지의 yaksok 소스가 자기 FFI를 `@키링`으로 self-mention하고, 이 패키지가 `alwaysEnabled`라 에디터에서 **무엇을 입력하든** 자동완성 경로의 `validate()`가 이 모듈을 검증하며 매번 크래시했습니다(사용자 코드 내용과 무관).

## 원인 — 두 개의 무가드 재진입 cycle (`CodeFile`)

1. **parse()**: `createDynamicRule` → `getRulesFromMentioningFile` → self 모듈의 `exportedRules` → 다시 `parse()`. ← 실제 크래시 지점 (스택 최상단의 `createTemplatePieceFromChoices`는 스택이 이미 가득 찬 오버플로 지점일 뿐)
2. **validate()**: `MentionScope.validate` → self 모듈의 `validate()` 다시 호출.

`run()`은 `ranScope` 캐시로 보호되지만 `parse()`/`validate()`에는 동등한 가드가 없었습니다.

## 수정

`CodeFile`에 재진입 가드(`parsing`, `validatingScopeInProgress`) 추가 — 이미 parse/validate 중인 파일이면 순환 고리를 끊습니다.

self-mention은 더 이상 resolve되지 않지만(순환 edge가 빈 규칙을 내므로), **크래시 대신 일반 검증 오류**로 graceful 종료됩니다. self-mention은 원래도 크래시였으므로 기능 회귀가 아니라 순수 개선입니다.

## 검증

- 회귀 테스트 추가: `test/mention-scope.test.ts` — 자기참조 모듈이 무한재귀 없이 종료
- `test` 워크스페이스 **531 passed / 0 failed**, 신규 테스트 파일 lint 클린
- 실제 `animal-keyring` yaksok 소스(163개 `@키링` self-mention): 수정 전 `RangeError` → 수정 후 정상 반환

## 후속

배포(jsr publish) 후 호랑 프론트엔드의 `@dalbit-yaksok/core` 버전업으로 근본 해결됩니다. (프론트엔드에는 self-mention 제거 우회 PR이 별도로 올라가 있음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)