### PR TITLE
fix(core): 선택 인자만 3개 이상인 약속이 호출되지 않던 문제

### DIFF
--- a/core/prepare/parse/dynamicRule/functions/get-function-templates.ts
+++ b/core/prepare/parse/dynamicRule/functions/get-function-templates.ts
@@ -53,7 +53,12 @@ export function convertTokensToFunctionTemplate(
                     type: PIECE_TYPE.DESTRUCTURE,
                     parameterElements: destructureNames,
                 })
-                i += destructureNames.length * 2 - 1
+                while (
+                    i < tokens.length &&
+                    tokens[i].type !== TOKEN_TYPE.CLOSING_PARENTHESIS
+                ) {
+                    i++
+                }
                 continue
             }
         }


### PR DESCRIPTION
## 문제
괄호 그룹을 `이름개수 * 2 - 1`칸 건너뛰어 `?`가 있으면 마지막 인자 이름이 STATIC으로 남았습니다. `약속, 전부선택(가?, 나?, 다?)`는 호출 규칙이 만들어지지 않았습니다.

## 수정
그룹을 읽은 뒤 닫는 `)`까지 걷습니다. 